### PR TITLE
Fix PP-Chart2Table tokenizer loading for paddle_dynamic with safetensors

### DIFF
--- a/paddlex/inference/models/common/tokenizer/qwen_tokenizer.py
+++ b/paddlex/inference/models/common/tokenizer/qwen_tokenizer.py
@@ -67,6 +67,7 @@ class QWenTokenizer(PretrainedTokenizer):
         vocab_file,
         errors="replace",
         padding_side="left",
+        extra_special_tokens=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -88,6 +89,8 @@ class QWenTokenizer(PretrainedTokenizer):
                 SPECIAL_TOKENS, start=len(self.mergeable_ranks)
             )
         }
+        if extra_special_tokens:
+            self.special_tokens.update(extra_special_tokens)
 
         enc = tiktoken.Encoding(
             "Qwen",

--- a/paddlex/inference/models/doc_vlm/predictor.py
+++ b/paddlex/inference/models/doc_vlm/predictor.py
@@ -285,7 +285,19 @@ class DocVLMLocalPredictor(LocalModelPredictor):
             )
         elif is_in_group(self.model_name, "PP-Chart2Table"):
             image_processor = GOTImageProcessor(1024)
-            tokenizer = QWenTokenizer.from_pretrained(self.model_dir)
+            # Load GOT-OCR2 special tokens (<img>, </img>, <imgpad>, etc.)
+            # from added_tokens.json so they encode as single tokens.
+            extra_special_tokens = None
+            added_tokens_file = Path(self.model_dir) / "added_tokens.json"
+            if added_tokens_file.exists():
+                import json
+
+                with open(added_tokens_file) as f:
+                    extra_special_tokens = json.load(f)
+            tokenizer = QWenTokenizer(
+                vocab_file=str(Path(self.model_dir) / "qwen.tiktoken"),
+                extra_special_tokens=extra_special_tokens,
+            )
             return PPChart2TableProcessor(
                 image_processor=image_processor, tokenizer=tokenizer, dtype=self.dtype
             )


### PR DESCRIPTION
The safetensors model directory uses HF tokenizer format (vocab.json + merges.txt) which is incompatible with QWenTokenizer's qwen.tiktoken format. Load qwen.tiktoken directly instead of using from_pretrained (which conflicts with the HF tokenizer_config.json).

Add extra_special_tokens parameter to QWenTokenizer to register the GOT-OCR2 tokens (<img>, </img>, <imgpad>, etc.) during construction so they encode as single tokens matching the model's expected IDs.