### PR TITLE
Fix PPLCNetConfig model_type to match HF convention

### DIFF
--- a/paddlex/inference/models/image_classification/modeling/_config.py
+++ b/paddlex/inference/models/image_classification/modeling/_config.py
@@ -43,7 +43,7 @@ DEFAULT_CONFIG = {
 
 
 class PPLCNetConfig(PretrainedConfig):
-    model_type = "cls"
+    model_type = "pp_lcnet"
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Change model_type from "cls" to "pp_lcnet" to align with the naming convention used in HuggingFace safetensors repos (PaddlePaddle/PP-LCNet_*_safetensors).