### PR TITLE
Remove unused rel_pos_x_bias and rel_pos_y_bias from PPDocLayoutV2

### DIFF
--- a/paddlex/inference/models/object_detection/modeling/pp_doclayout_v2.py
+++ b/paddlex/inference/models/object_detection/modeling/pp_doclayout_v2.py
@@ -383,8 +383,6 @@ class PPDocLayoutV2ReadingOrderEncoder(nn.Layer):
         if self.has_spatial_attention_bias:
             self.max_rel_2d_pos = config.max_rel_2d_pos
             self.rel_2d_pos_bins = config.rel_2d_pos_bins
-            self.rel_pos_x_bias = nn.Linear(self.rel_2d_pos_bins, config.num_attention_heads, bias_attr=False)
-            self.rel_pos_y_bias = nn.Linear(self.rel_2d_pos_bins, config.num_attention_heads, bias_attr=False)
         self.rel_bias_module = PPDocLayoutV2PositionRelationEmbedding(config)
 
     def relative_position_bucket(self, relative_position, bidirectional=True, num_buckets=32, max_distance=128):


### PR DESCRIPTION
forward() 中从未使用。实际的 2D 位置编码由 rel_bias_module（PPDocLayoutV2PositionRelationEmbedding）计算。
                                                                                                                                       
每次加载模型时都会产生警告：Some weights of PPDocLayoutV2 were not initialized from the model checkpoint: ['reading_order.encoder.rel_pos_x_bias.weight', 'reading_order.encoder.rel_pos_y_bias.weight']